### PR TITLE
feature/file-checkin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # *vvrest* release changelog
 
+## v1.5.0
+- add optional parameter `check_in` to `FileService.file_upload`
+
 ## v1.4.0
 - add optional parameter `jwt` to `Vault`. if passed in, this
 optional parameter will be used as the `Token.access_token`

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as readme:
 
 setuptools.setup(
     name='vvrest',
-    version='1.4.0',
+    version='1.5.0',
     author='Jared Runyon',
     author_email='jared.runyon@visualvault.com',
     maintainer='Jared Runyon',

--- a/tests/file_service_test.py
+++ b/tests/file_service_test.py
@@ -79,7 +79,7 @@ class FileServiceTest(unittest.TestCase):
         file_service = FileService(self.vault)
         resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
                                         'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name,
-                                        check_in=True)
+                                        check_in=0)
 
         self.assertEqual(resp['meta']['status'], 200)
         self.assertEqual(resp['data']['documentId'], self.document_id)
@@ -97,7 +97,7 @@ class FileServiceTest(unittest.TestCase):
         file_service = FileService(self.vault)
         resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
                                         'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name,
-                                        check_in=False)
+                                        check_in=1)
 
         self.assertEqual(resp['meta']['status'], 200)
         self.assertEqual(resp['data']['documentId'], self.document_id)

--- a/tests/file_service_test.py
+++ b/tests/file_service_test.py
@@ -79,7 +79,7 @@ class FileServiceTest(unittest.TestCase):
         file_service = FileService(self.vault)
         resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
                                         'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name,
-                                        check_in=0)
+                                        check_in=True)
 
         self.assertEqual(resp['meta']['status'], 200)
         self.assertEqual(resp['data']['documentId'], self.document_id)
@@ -97,7 +97,7 @@ class FileServiceTest(unittest.TestCase):
         file_service = FileService(self.vault)
         resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
                                         'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name,
-                                        check_in=1)
+                                        check_in=False)
 
         self.assertEqual(resp['meta']['status'], 200)
         self.assertEqual(resp['data']['documentId'], self.document_id)

--- a/tests/file_service_test.py
+++ b/tests/file_service_test.py
@@ -52,3 +52,60 @@ class FileServiceTest(unittest.TestCase):
         # stream_stats = vars(stream)
         # self.assertEqual(stream_stats['status_code'], 200)
         # self.assertEqual(stream_stats['headers']['Content-Type'], 'application/octet-stream')
+
+    def test_file_upload_check_in(self):
+        """
+        validate FileService.file_upload check_in functionality
+        """
+        # validate default checkIn
+        expected_revision = generate_random_uuid()
+        file_service = FileService(self.vault)
+        resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
+                                        'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name)
+
+        self.assertEqual(resp['meta']['status'], 200)
+        self.assertEqual(resp['data']['documentId'], self.document_id)
+        self.assertEqual(resp['data']['revision'], expected_revision)
+        self.assertEqual(resp['data']['checkInStatus'], 0)
+
+        new_file_id = resp['data']['id']
+        stream = file_service.get_file_stream(new_file_id)
+        stream_stats = vars(stream)
+        self.assertEqual(stream_stats['status_code'], 200)
+        self.assertEqual(stream_stats['headers']['Content-Type'], 'application/octet-stream')
+
+        # validate checkIn True
+        expected_revision = generate_random_uuid()
+        file_service = FileService(self.vault)
+        resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
+                                        'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name,
+                                        check_in=True)
+
+        self.assertEqual(resp['meta']['status'], 200)
+        self.assertEqual(resp['data']['documentId'], self.document_id)
+        self.assertEqual(resp['data']['revision'], expected_revision)
+        self.assertEqual(resp['data']['checkInStatus'], 0)
+
+        new_file_id = resp['data']['id']
+        stream = file_service.get_file_stream(new_file_id)
+        stream_stats = vars(stream)
+        self.assertEqual(stream_stats['status_code'], 200)
+        self.assertEqual(stream_stats['headers']['Content-Type'], 'application/octet-stream')
+
+        # validate checkIn False
+        expected_revision = generate_random_uuid()
+        file_service = FileService(self.vault)
+        resp = file_service.file_upload(self.document_id, 'unittest', expected_revision, 'unittest change reason',
+                                        'Released', '', 'unittest.txt', self.file_path + '/' + self.file_upload_name,
+                                        check_in=False)
+
+        self.assertEqual(resp['meta']['status'], 200)
+        self.assertEqual(resp['data']['documentId'], self.document_id)
+        self.assertEqual(resp['data']['revision'], expected_revision)
+        self.assertEqual(resp['data']['checkInStatus'], 1)
+
+        new_file_id = resp['data']['id']
+        stream = file_service.get_file_stream(new_file_id)
+        stream_stats = vars(stream)
+        self.assertEqual(stream_stats['status_code'], 200)
+        self.assertEqual(stream_stats['headers']['Content-Type'], 'application/octet-stream')

--- a/vvrest/services/file_service.py
+++ b/vvrest/services/file_service.py
@@ -36,7 +36,7 @@ class FileService:
         return stream
 
     def file_upload(self, document_id, name, revision, change_reason, check_in_state, index_fields, file_name,
-                    file_path, check_in=True):
+                    file_path, check_in=0):
         """
         :param document_id: string uuid4
         :param name: string
@@ -46,7 +46,7 @@ class FileService:
         :param index_fields: string dict, example: "{'testFIELD': 'the value'}"
         :param file_name: string
         :param file_path: string
-        :param check_in: bool, default: True
+        :param check_in: int, default: 0, format: 0 -> CheckedIn, 1 -> CheckedOut (checkInStatus ENUM value)
         :return: dict
         """
         request_url = self.vault.base_url + FILES_URL

--- a/vvrest/services/file_service.py
+++ b/vvrest/services/file_service.py
@@ -36,7 +36,7 @@ class FileService:
         return stream
 
     def file_upload(self, document_id, name, revision, change_reason, check_in_state, index_fields, file_name,
-                    file_path, check_in=0):
+                    file_path, check_in=True):
         """
         :param document_id: string uuid4
         :param name: string
@@ -46,7 +46,7 @@ class FileService:
         :param index_fields: string dict, example: "{'testFIELD': 'the value'}"
         :param file_name: string
         :param file_path: string
-        :param check_in: int, default: 0, format: 0 -> CheckedIn, 1 -> CheckedOut (checkInStatus ENUM value)
+        :param check_in: bool, default: True
         :return: dict
         """
         request_url = self.vault.base_url + FILES_URL

--- a/vvrest/services/file_service.py
+++ b/vvrest/services/file_service.py
@@ -35,7 +35,8 @@ class FileService:
 
         return stream
 
-    def file_upload(self, document_id, name, revision, change_reason, check_in_state, index_fields, file_name, file_path):
+    def file_upload(self, document_id, name, revision, change_reason, check_in_state, index_fields, file_name,
+                    file_path, check_in=True):
         """
         :param document_id: string uuid4
         :param name: string
@@ -45,6 +46,7 @@ class FileService:
         :param index_fields: string dict, example: "{'testFIELD': 'the value'}"
         :param file_name: string
         :param file_path: string
+        :param check_in: bool, default: True
         :return: dict
         """
         request_url = self.vault.base_url + FILES_URL
@@ -57,7 +59,8 @@ class FileService:
             'changeReason': change_reason,
             'checkInDocumentState': check_in_state,
             'indexFields': index_fields,
-            'fileName': file_name
+            'fileName': file_name,
+            'checkIn': check_in
         }
 
         with open(file_path, 'rb') as file_stream:  # open file stream

--- a/vvrest/services/file_service.py
+++ b/vvrest/services/file_service.py
@@ -52,7 +52,7 @@ class FileService:
         request_url = self.vault.base_url + FILES_URL
         headers = self.vault.get_auth_headers()
 
-        params = {
+        payload = {
             'documentId': document_id,
             'name': name,
             'revision': revision,
@@ -65,6 +65,6 @@ class FileService:
 
         with open(file_path, 'rb') as file_stream:  # open file stream
             files = {'fileUpload': (file_name, file_stream, 'application/octet-stream')}
-            resp = requests.post(request_url, headers=headers, data=params, files=files).json()
+            resp = requests.post(request_url, headers=headers, data=payload, files=files).json()
 
         return resp


### PR DESCRIPTION
- add optional parameter `check_in` to `FileService.file_upload`

NOTE: new `test` failing right now because change is not deployed to `vv`. once change is deployed to `vv`, the `test` should pass and the feature can be merged/released to `pypi`